### PR TITLE
Telemetry

### DIFF
--- a/LibreRally.Tests/VehicleSpawnerInputTests.cs
+++ b/LibreRally.Tests/VehicleSpawnerInputTests.cs
@@ -37,6 +37,15 @@ namespace LibreRally.Tests
 		}
 
 		[Fact]
+		public void ResolveTelemetryMenuAction_MapsIndexesToExpectedActions()
+		{
+			Assert.Equal(TelemetryMenuAction.ToggleOutGauge, VehicleSpawner.ResolveTelemetryMenuAction(0));
+			Assert.Equal(TelemetryMenuAction.ReconnectOutGauge, VehicleSpawner.ResolveTelemetryMenuAction(3));
+			Assert.Equal(TelemetryMenuAction.ToggleOutSim, VehicleSpawner.ResolveTelemetryMenuAction(4));
+			Assert.Equal(TelemetryMenuAction.ReconnectOutSim, VehicleSpawner.ResolveTelemetryMenuAction(7));
+		}
+
+		[Fact]
 		public void IsVehicleMenuConfirmRequested_AcceptsControllerA()
 		{
 			bool requested = VehicleSpawner.IsVehicleMenuConfirmRequested(

--- a/LibreRally.Tests/VehicleSpawnerPauseMenuTests.cs
+++ b/LibreRally.Tests/VehicleSpawnerPauseMenuTests.cs
@@ -23,7 +23,13 @@ namespace LibreRally.Tests
 					Assert.Contains("spawn point", entry.Item.Description, StringComparison.OrdinalIgnoreCase);
 				},
 				entry => Assert.Equal(PauseMenuAction.GarageSetup, entry.Action),
-				entry => Assert.Equal(PauseMenuAction.VehicleSelect, entry.Action));
+				entry => Assert.Equal(PauseMenuAction.VehicleSelect, entry.Action),
+				entry => Assert.Equal(PauseMenuAction.PhysicsCalibration, entry.Action),
+				entry =>
+				{
+					Assert.Equal(PauseMenuAction.Telemetry, entry.Action);
+					Assert.Equal("Telemetry", entry.Item.Title);
+				});
 		}
 
 		[Fact]
@@ -32,6 +38,14 @@ namespace LibreRally.Tests
 			var action = VehicleSpawner.ResolvePauseMenuAction(2);
 
 			Assert.Equal(PauseMenuAction.GarageSetup, action);
+		}
+
+		[Fact]
+		public void ResolvePauseMenuAction_ReturnsTelemetryForSixthSlot()
+		{
+			var action = VehicleSpawner.ResolvePauseMenuAction(5);
+
+			Assert.Equal(PauseMenuAction.Telemetry, action);
 		}
 	}
 }

--- a/LibreRally/HUD/TelemetryOverlay.cs
+++ b/LibreRally/HUD/TelemetryOverlay.cs
@@ -1,0 +1,402 @@
+using System;
+using System.Collections.Generic;
+using Myra;
+using Myra.Graphics2D.Brushes;
+using Myra.Graphics2D.UI;
+using Stride.Core;
+using Stride.Core.Mathematics;
+using Stride.Engine;
+using Stride.Games;
+
+namespace LibreRally.HUD
+{
+	/// <summary>
+	/// UI overlay for in-game telemetry control.
+	/// </summary>
+	public sealed class TelemetryOverlay : GameSystemBase
+	{
+		private static readonly Color BackdropColor = new(5, 8, 14, 180);
+		private static readonly Color ShellColor = new(16, 22, 30, 242);
+		private static readonly Color AccentSoftColor = new(214, 148, 78, 84);
+		private static readonly Color PanelColor = new(26, 32, 43, 236);
+		private static readonly Color TitleColor = new(240, 243, 247, 255);
+		private static readonly Color CopyColor = new(183, 193, 205, 255);
+		private static readonly Color ValueColor = new(255, 230, 204, 255);
+		private static readonly SolidBrush BackdropBrush = new(BackdropColor);
+		private static readonly SolidBrush ShellBrush = new(ShellColor);
+		private static readonly SolidBrush PanelBrush = new(PanelColor);
+		private static readonly SolidBrush SelectedItemBrush = new(AccentSoftColor);
+		private static readonly SolidBrush UnselectedItemBrush = new(PanelColor);
+
+		private readonly List<(Button Button, Label Title, Label Description)> _buttons = [];
+		private IReadOnlyList<PauseMenuItem> _items = [];
+		private string _vehicleName = string.Empty;
+		private string _statusText = string.Empty;
+		private string _outGaugeSummary = string.Empty;
+		private string _outSimSummary = string.Empty;
+		private int _selectedIndex;
+		private bool _overlayVisible;
+		private Game? _game;
+		private Desktop? _desktop;
+		private Label? _vehicleNameLabel;
+		private Label? _statusLabel;
+		private Label? _outGaugeSummaryLabel;
+		private Label? _outSimSummaryLabel;
+
+		/// <summary>
+		/// Gets or sets the telemetry menu items to display.
+		/// </summary>
+		public IReadOnlyList<PauseMenuItem> Items
+		{
+			get => _items;
+			set
+			{
+				_items = value;
+				RebuildRoot();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the selected telemetry item index.
+		/// </summary>
+		public int SelectedIndex
+		{
+			get => _selectedIndex;
+			set
+			{
+				_selectedIndex = value;
+				UpdateSelectionStyles();
+				FocusSelectedButton();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this overlay is visible.
+		/// </summary>
+		public bool OverlayVisible
+		{
+			get => _overlayVisible;
+			set
+			{
+				_overlayVisible = value;
+				FocusSelectedButton();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the vehicle name shown in the header.
+		/// </summary>
+		public string VehicleName
+		{
+			get => _vehicleName;
+			set
+			{
+				_vehicleName = value ?? string.Empty;
+				UpdateLabels();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the status text shown at the bottom of the overlay.
+		/// </summary>
+		public string StatusText
+		{
+			get => _statusText;
+			set
+			{
+				_statusText = value ?? string.Empty;
+				UpdateLabels();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the OutGauge telemetry summary.
+		/// </summary>
+		public string OutGaugeSummary
+		{
+			get => _outGaugeSummary;
+			set
+			{
+				_outGaugeSummary = value ?? string.Empty;
+				UpdateLabels();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the OutSim telemetry summary.
+		/// </summary>
+		public string OutSimSummary
+		{
+			get => _outSimSummary;
+			set
+			{
+				_outSimSummary = value ?? string.Empty;
+				UpdateLabels();
+			}
+		}
+
+		/// <summary>
+		/// Raised when a telemetry item is activated.
+		/// </summary>
+		public Action<int>? ItemActivated { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="TelemetryOverlay"/> class.
+		/// </summary>
+		/// <param name="services">The Stride service registry.</param>
+		public TelemetryOverlay(IServiceRegistry services) : base(services)
+		{
+			Enabled = true;
+			Visible = true;
+			DrawOrder = 9997;
+			UpdateOrder = 9997;
+		}
+
+		/// <summary>
+		/// Initializes the telemetry overlay desktop UI.
+		/// </summary>
+		public override void Initialize()
+		{
+			base.Initialize();
+
+			_game = (Game?)Services.GetService<IGame>();
+			if (_game == null)
+			{
+				return;
+			}
+
+			MyraEnvironment.Game = _game;
+			_desktop = new Desktop
+			{
+				Root = BuildRoot(),
+			};
+			FocusSelectedButton();
+		}
+
+		protected override void Destroy()
+		{
+			_desktop?.Dispose();
+			base.Destroy();
+		}
+
+		/// <summary>
+		/// Draws the telemetry overlay when it is visible.
+		/// </summary>
+		/// <param name="gameTime">Stride timing data for the current frame.</param>
+		public override void Draw(GameTime gameTime)
+		{
+			if (!OverlayVisible || _game == null || _desktop == null)
+			{
+				return;
+			}
+
+			var presenter = _game.GraphicsDevice.Presenter;
+			if (presenter?.BackBuffer == null)
+			{
+				return;
+			}
+
+			var context = _game.GraphicsContext;
+			context.CommandList.SetRenderTargetAndViewport(presenter.DepthStencilBuffer, presenter.BackBuffer);
+			_desktop.Render();
+		}
+
+		private Widget BuildRoot()
+		{
+			_buttons.Clear();
+
+			var root = new Panel
+			{
+				Background = BackdropBrush,
+			};
+
+			var shellFrame = new Panel
+			{
+				Width = 900,
+				Height = 690,
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Center,
+				Background = ShellBrush,
+			};
+
+			var shell = new VerticalStackPanel
+			{
+				Width = 840,
+				Height = 630,
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Center,
+				Spacing = 12,
+			};
+
+			shell.Widgets.Add(new Label
+			{
+				Text = "Telemetry",
+				TextColor = TitleColor,
+			});
+
+			_vehicleNameLabel = new Label
+			{
+				TextColor = ValueColor,
+			};
+			shell.Widgets.Add(_vehicleNameLabel);
+
+			shell.Widgets.Add(new Label
+			{
+				Text = "D-Pad Up/Down select  •  A activate  •  B/Esc/Start back out",
+				TextColor = CopyColor,
+				Wrap = true,
+			});
+
+			_outGaugeSummaryLabel = new Label
+			{
+				TextColor = ValueColor,
+				Wrap = true,
+			};
+			shell.Widgets.Add(_outGaugeSummaryLabel);
+
+			_outSimSummaryLabel = new Label
+			{
+				TextColor = ValueColor,
+				Wrap = true,
+			};
+			shell.Widgets.Add(_outSimSummaryLabel);
+
+			var list = new VerticalStackPanel
+			{
+				Width = 780,
+				Spacing = 8,
+				HorizontalAlignment = HorizontalAlignment.Center,
+				VerticalAlignment = VerticalAlignment.Top,
+			};
+
+			for (var index = 0; index < _items.Count; index++)
+			{
+				list.Widgets.Add(CreateMenuButton(_items[index], index));
+			}
+
+			shell.Widgets.Add(new Panel
+			{
+				Height = 410,
+				Background = PanelBrush,
+				Widgets =
+				{
+					new ScrollViewer
+					{
+						Content = list,
+						Height = 382,
+						VerticalAlignment = VerticalAlignment.Stretch,
+					},
+				},
+			});
+
+			_statusLabel = new Label
+			{
+				TextColor = CopyColor,
+				Wrap = true,
+			};
+			shell.Widgets.Add(_statusLabel);
+
+			shellFrame.Widgets.Add(shell);
+			root.Widgets.Add(shellFrame);
+
+			UpdateSelectionStyles();
+			UpdateLabels();
+			return root;
+		}
+
+		private Button CreateMenuButton(PauseMenuItem item, int index)
+		{
+			var titleLabel = new Label
+			{
+				Text = item.Title,
+				TextColor = TitleColor,
+			};
+			var descriptionLabel = new Label
+			{
+				Text = item.Description,
+				TextColor = CopyColor,
+				Wrap = true,
+			};
+
+			var content = new VerticalStackPanel
+			{
+				Spacing = 4,
+			};
+			content.Widgets.Add(titleLabel);
+			content.Widgets.Add(descriptionLabel);
+
+			var button = new Button
+			{
+				Height = 78,
+				HorizontalAlignment = HorizontalAlignment.Stretch,
+				Content = content,
+			};
+			button.Click += (_, _) =>
+			{
+				SelectedIndex = index;
+				ItemActivated?.Invoke(index);
+			};
+
+			_buttons.Add((button, titleLabel, descriptionLabel));
+			return button;
+		}
+
+		private void RebuildRoot()
+		{
+			if (_desktop == null)
+			{
+				return;
+			}
+
+			_desktop.Root = BuildRoot();
+			FocusSelectedButton();
+		}
+
+		private void UpdateSelectionStyles()
+		{
+			var clampedIndex = _buttons.Count == 0 ? 0 : Math.Clamp(SelectedIndex, 0, _buttons.Count - 1);
+			for (var i = 0; i < _buttons.Count; i++)
+			{
+				var isSelected = i == clampedIndex;
+				var (button, title, description) = _buttons[i];
+				button.Background = isSelected ? SelectedItemBrush : UnselectedItemBrush;
+				title.TextColor = isSelected ? ValueColor : TitleColor;
+				description.TextColor = isSelected ? ValueColor : CopyColor;
+			}
+		}
+
+		private void UpdateLabels()
+		{
+			if (_vehicleNameLabel != null)
+			{
+				_vehicleNameLabel.Text = string.IsNullOrWhiteSpace(_vehicleName) ? "LibreRally" : _vehicleName;
+			}
+
+			if (_outGaugeSummaryLabel != null)
+			{
+				_outGaugeSummaryLabel.Text = _outGaugeSummary;
+			}
+
+			if (_outSimSummaryLabel != null)
+			{
+				_outSimSummaryLabel.Text = _outSimSummary;
+			}
+
+			if (_statusLabel != null)
+			{
+				_statusLabel.Text = _statusText;
+			}
+		}
+
+		private void FocusSelectedButton()
+		{
+			if (!_overlayVisible || _desktop == null || _buttons.Count == 0)
+			{
+				return;
+			}
+
+			var clampedIndex = Math.Clamp(_selectedIndex, 0, _buttons.Count - 1);
+			_desktop.FocusedKeyboardWidget = _buttons[clampedIndex].Button;
+		}
+	}
+}

--- a/LibreRally/LibreRally.csproj
+++ b/LibreRally/LibreRally.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommentSense" Version="1.0.0" />
+    <PackageReference Include="JetBrains.Annotations" Version="2025.2.4" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="18.4.0" />
     <PackageReference Include="Myra.Stride" Version="1.5.11" />
     <PackageReference Include="Stride.Engine" Version="4.3.0.2507" />

--- a/LibreRally/VehicleSpawner.cs
+++ b/LibreRally/VehicleSpawner.cs
@@ -36,6 +36,8 @@ namespace LibreRally
 		VehicleSelect,
 		/// <summary>Open the physics calibration menu.</summary>
 		PhysicsCalibration,
+		/// <summary>Open the telemetry controls menu.</summary>
+		Telemetry,
 	}
 
 	/// <summary>
@@ -44,6 +46,21 @@ namespace LibreRally
 	/// <param name="Item">The UI item descriptor.</param>
 	/// <param name="Action">The action to execute when selected.</param>
 	public readonly record struct PauseMenuEntry(PauseMenuItem Item, PauseMenuAction Action);
+
+	/// <summary>
+	/// Defines the available actions in the telemetry menu.
+	/// </summary>
+	internal enum TelemetryMenuAction
+	{
+		ToggleOutGauge,
+		ConnectOutGauge,
+		DisconnectOutGauge,
+		ReconnectOutGauge,
+		ToggleOutSim,
+		ConnectOutSim,
+		DisconnectOutSim,
+		ReconnectOutSim,
+	}
 
 	/// <summary>
 	/// Main script responsible for spawning vehicles, managing UI overlays, and handling telemetry.
@@ -71,7 +88,7 @@ namespace LibreRally
 		/// <summary>
 		/// Gets or sets a value indicating whether OutGauge telemetry is enabled.
 		/// </summary>
-		public bool OutGaugeEnabled { get; set; }
+		public bool OutGaugeEnabled { get; set; } = true;
 
 		/// <summary>
 		/// Gets or sets the delay between OutGauge packets in centiseconds.
@@ -125,15 +142,18 @@ namespace LibreRally
 		private SetupUiShellOverlay? _setupUiShellOverlay;
 		private VehicleSelectionOverlay? _vehicleSelectionOverlay;
 		private PhysicsCalibrationOverlay? _physicsCalibrationOverlay;
+		private TelemetryOverlay? _telemetryOverlay;
 		private BeamNgVehicleCatalog? _vehicleCatalog;
 		private List<BeamNgVehicleDescriptor> _availableVehicles = [];
 		private readonly VehicleSetupOverrides _setupOverrides = new();
 		private int _selectedVehicleIndex;
 		private int _pauseMenuSelectedIndex;
+		private int _telemetryMenuSelectedIndex;
 		private bool _vehicleSelectionOpenedFromPauseMenu;
 		private MenuScreen _activeMenuScreen;
 		private LoadedVehicle? _loadedVehicle;
 		private UdpClient? _outGaugeClient;
+		private bool _outGaugeConnectionRequested = true;
 		private string? _outGaugeTargetHost;
 		private int _outGaugeTargetPort;
 		private const double FailureLogIntervalSeconds = 5d;
@@ -141,6 +161,7 @@ namespace LibreRally
 		private double _outGaugeNextFailureLogTimeSeconds;
 		private float _outGaugeElapsed;
 		private UdpClient? _outSimClient;
+		private bool _outSimConnectionRequested = true;
 		private string? _outSimTargetHost;
 		private int _outSimTargetPort;
 		private bool _outSimSendFailed;
@@ -162,7 +183,9 @@ namespace LibreRally
 		private const int PauseMenuGarageSetupIndex = 2;
 		private const int PauseMenuVehicleSelectIndex = 3;
 		private const int PauseMenuPhysicsCalibrationIndex = 4;
-		private const int PauseMenuItemCount = 5;
+		private const int PauseMenuTelemetryIndex = 5;
+		private const int PauseMenuItemCount = 6;
+		private const int TelemetryMenuItemCount = 8;
 		private static readonly IReadOnlyList<PauseMenuEntry> PauseMenuEntries =
 		[
 			new(new PauseMenuItem("Resume Driving", "Return to the stage and hand control back to the driver."), PauseMenuAction.ResumeDriving),
@@ -170,6 +193,7 @@ namespace LibreRally
 			new(new PauseMenuItem("Garage Setup", "Open the restored Myra tuning shell for stage prep changes."), PauseMenuAction.GarageSetup),
 			new(new PauseMenuItem("Vehicle Select", "Load a different bundled vehicle from the current catalog."), PauseMenuAction.VehicleSelect),
 			new(new PauseMenuItem("Physics Calibration", "Isolate tyre model contributions and tune anti-slip parameters live."), PauseMenuAction.PhysicsCalibration),
+			new(new PauseMenuItem("Telemetry", "Enable or disable OutGauge/OutSim, then connect, disconnect, or reconnect their UDP sockets."), PauseMenuAction.Telemetry),
 		];
 
 		internal enum MenuScreen
@@ -179,6 +203,7 @@ namespace LibreRally
 			GarageSetup,
 			VehicleSelection,
 			PhysicsCalibration,
+			Telemetry,
 		}
 
 		/// <summary>
@@ -216,6 +241,7 @@ namespace LibreRally
 			EnsureSetupUiShellOverlay();
 			EnsureVehicleSelectionOverlay();
 			EnsurePhysicsCalibrationOverlay();
+			EnsureTelemetryOverlay();
 
 			try
 			{
@@ -287,6 +313,7 @@ namespace LibreRally
 			AttachDrivingHud(vehicle.CarComponent);
 			BindGarageSetupOverlay();
 			BindPhysicsCalibrationOverlay();
+			RefreshTelemetryOverlay();
 		}
 
 		private void UnloadVehicle()
@@ -427,6 +454,32 @@ namespace LibreRally
 			((Game)Game).GameSystems.Add(_physicsCalibrationOverlay);
 		}
 
+		private void EnsureTelemetryOverlay()
+		{
+			if (_telemetryOverlay != null)
+			{
+				return;
+			}
+
+			_telemetryOverlay = new TelemetryOverlay(Services)
+			{
+				Items = BuildTelemetryMenuItems(),
+				SelectedIndex = _telemetryMenuSelectedIndex,
+				OverlayVisible = _activeMenuScreen == MenuScreen.Telemetry,
+				VehicleName = GetCurrentVehicleName(),
+				StatusText = _status,
+				OutGaugeSummary = BuildOutGaugeSummary(),
+				OutSimSummary = BuildOutSimSummary(),
+			};
+			_telemetryOverlay.ItemActivated = selectedIndex =>
+			{
+				_telemetryMenuSelectedIndex = Math.Clamp(selectedIndex, 0, TelemetryMenuItemCount - 1);
+				ExecuteTelemetryMenuAction(ResolveTelemetryMenuAction(_telemetryMenuSelectedIndex));
+			};
+
+			((Game)Game).GameSystems.Add(_telemetryOverlay);
+		}
+
 		private void BindPhysicsCalibrationOverlay()
 		{
 			if (_physicsCalibrationOverlay == null)
@@ -509,6 +562,9 @@ namespace LibreRally
 		internal static bool IsVehicleMenuCancelRequested(bool keyboardCancelPressed, bool controllerCancelPressed) =>
 			keyboardCancelPressed || controllerCancelPressed;
 
+		internal static TelemetryMenuAction ResolveTelemetryMenuAction(int selectedIndex) =>
+			(TelemetryMenuAction)Math.Clamp(selectedIndex, 0, TelemetryMenuItemCount - 1);
+
 		private void HandlePauseAndVehicleSelectionInput()
 		{
 			var pad = Input.GamePads.FirstOrDefault();
@@ -529,6 +585,27 @@ namespace LibreRally
 
 			if (_activeMenuScreen == MenuScreen.PhysicsCalibration)
 			{
+				if (_car != null)
+				{
+					_car.PlayerInputEnabled = false;
+				}
+
+				return;
+			}
+
+			if (_activeMenuScreen == MenuScreen.Telemetry)
+			{
+				if (IsVehicleMenuCancelRequested(
+					    Input.IsKeyPressed(Keys.Escape) || pauseMenuToggleRequested,
+					    (pad?.IsButtonPressed(GamePadButton.B) ?? false) || (pad?.IsButtonPressed(GamePadButton.Start) ?? false)))
+				{
+					CloseTelemetryMenu();
+				}
+				else
+				{
+					HandleTelemetryMenuInput(pad);
+				}
+
 				if (_car != null)
 				{
 					_car.PlayerInputEnabled = false;
@@ -674,7 +751,38 @@ namespace LibreRally
 				case PauseMenuPhysicsCalibrationIndex:
 					ExecutePauseMenuAction(PauseMenuAction.PhysicsCalibration);
 					break;
+				case PauseMenuTelemetryIndex:
+					ExecutePauseMenuAction(PauseMenuAction.Telemetry);
+					break;
 			}
+		}
+
+		private void HandleTelemetryMenuInput(IGamePadDevice? pad)
+		{
+			if (IsVehicleMenuMoveUpRequested(
+				    Input.IsKeyPressed(Keys.Up),
+				    pad?.IsButtonPressed(GamePadButton.PadUp) ?? false))
+			{
+				_telemetryMenuSelectedIndex = (_telemetryMenuSelectedIndex - 1 + TelemetryMenuItemCount) % TelemetryMenuItemCount;
+				RefreshTelemetryOverlay();
+			}
+
+			if (IsVehicleMenuMoveDownRequested(
+				    Input.IsKeyPressed(Keys.Down),
+				    pad?.IsButtonPressed(GamePadButton.PadDown) ?? false))
+			{
+				_telemetryMenuSelectedIndex = (_telemetryMenuSelectedIndex + 1) % TelemetryMenuItemCount;
+				RefreshTelemetryOverlay();
+			}
+
+			if (!IsVehicleMenuConfirmRequested(
+				    Input.IsKeyPressed(Keys.Enter),
+				    pad?.IsButtonPressed(GamePadButton.A) ?? false))
+			{
+				return;
+			}
+
+			ExecuteTelemetryMenuAction(ResolveTelemetryMenuAction(_telemetryMenuSelectedIndex));
 		}
 
 		private void ExecutePauseMenuAction(PauseMenuAction action)
@@ -695,6 +803,42 @@ namespace LibreRally
 					break;
 				case PauseMenuAction.PhysicsCalibration:
 					OpenPhysicsCalibration();
+					break;
+				case PauseMenuAction.Telemetry:
+					OpenTelemetryMenu();
+					break;
+			}
+		}
+
+		private void ExecuteTelemetryMenuAction(TelemetryMenuAction action)
+		{
+			switch (action)
+			{
+				case TelemetryMenuAction.ToggleOutGauge:
+					SetOutGaugeEnabled(!OutGaugeEnabled);
+					SetTelemetryStatus($"OutGauge telemetry {(OutGaugeEnabled ? "enabled" : "disabled")}.");
+					break;
+				case TelemetryMenuAction.ConnectOutGauge:
+					ConnectOutGauge();
+					break;
+				case TelemetryMenuAction.DisconnectOutGauge:
+					DisconnectOutGauge();
+					break;
+				case TelemetryMenuAction.ReconnectOutGauge:
+					ReconnectOutGauge();
+					break;
+				case TelemetryMenuAction.ToggleOutSim:
+					SetOutSimEnabled(!OutSimEnabled);
+					SetTelemetryStatus($"OutSim telemetry {(OutSimEnabled ? "enabled" : "disabled")}.");
+					break;
+				case TelemetryMenuAction.ConnectOutSim:
+					ConnectOutSim();
+					break;
+				case TelemetryMenuAction.DisconnectOutSim:
+					DisconnectOutSim();
+					break;
+				case TelemetryMenuAction.ReconnectOutSim:
+					ReconnectOutSim();
 					break;
 			}
 		}
@@ -750,6 +894,19 @@ namespace LibreRally
 		{
 			_activeMenuScreen = MenuScreen.Pause;
 			_pauseMenuSelectedIndex = PauseMenuPhysicsCalibrationIndex;
+		}
+
+		private void OpenTelemetryMenu()
+		{
+			RefreshTelemetryOverlay();
+			_activeMenuScreen = MenuScreen.Telemetry;
+		}
+
+		private void CloseTelemetryMenu()
+		{
+			_activeMenuScreen = MenuScreen.Pause;
+			_pauseMenuSelectedIndex = PauseMenuTelemetryIndex;
+			RefreshTelemetryOverlay();
 		}
 
 		private void ApplyGarageSetupChanges(SetupUiApplyPayload payload)
@@ -1079,6 +1236,16 @@ namespace LibreRally
 				_pauseMenuOverlay.StatusText = _status;
 			}
 
+			if (_telemetryOverlay != null)
+			{
+				_telemetryOverlay.SelectedIndex = _telemetryMenuSelectedIndex;
+				_telemetryOverlay.OverlayVisible = _activeMenuScreen == MenuScreen.Telemetry;
+				_telemetryOverlay.VehicleName = GetCurrentVehicleName();
+				_telemetryOverlay.StatusText = _status;
+				_telemetryOverlay.OutGaugeSummary = BuildOutGaugeSummary();
+				_telemetryOverlay.OutSimSummary = BuildOutSimSummary();
+			}
+
 			if (_setupUiShellOverlay != null)
 			{
 				_setupUiShellOverlay.OverlayVisible = _activeMenuScreen == MenuScreen.GarageSetup;
@@ -1101,10 +1268,10 @@ namespace LibreRally
 
 		private void SendOutGaugeTelemetry(float deltaTime)
 		{
-			if (!OutGaugeEnabled || _car == null)
+			if (!OutGaugeEnabled || !_outGaugeConnectionRequested || _car == null)
 			{
 				_outGaugeElapsed = 0f;
-				if (!OutGaugeEnabled)
+				if (!OutGaugeEnabled || !_outGaugeConnectionRequested)
 				{
 					DisposeOutGaugeClient();
 				}
@@ -1196,11 +1363,11 @@ namespace LibreRally
 
 		private void SendOutSimTelemetry(float deltaTime)
 		{
-			if (!OutSimEnabled || _car == null)
+			if (!OutSimEnabled || !_outSimConnectionRequested || _car == null)
 			{
 				_outSimElapsed = 0f;
 				_outSimHasPreviousLinearVelocity = false;
-				if (!OutSimEnabled)
+				if (!OutSimEnabled || !_outSimConnectionRequested)
 				{
 					DisposeOutSimClient();
 				}
@@ -1314,6 +1481,155 @@ namespace LibreRally
 			}
 
 			_outSimSendFailed = true;
+		}
+
+		private IReadOnlyList<PauseMenuItem> BuildTelemetryMenuItems() =>
+		[
+			new(OutGaugeEnabled ? "Disable OutGauge" : "Enable OutGauge", "Toggle Live for Speed OutGauge speed/RPM packets on or off."),
+			new("Connect OutGauge", "Open the OutGauge UDP socket without changing the enable toggle."),
+			new("Disconnect OutGauge", "Close the OutGauge UDP socket while keeping the configured target intact."),
+			new("Reconnect OutGauge", "Dispose and recreate the OutGauge UDP socket for the current endpoint."),
+			new(OutSimEnabled ? "Disable OutSim" : "Enable OutSim", "Toggle Live for Speed OutSim motion packets on or off."),
+			new("Connect OutSim", "Open the OutSim UDP socket without changing the enable toggle."),
+			new("Disconnect OutSim", "Close the OutSim UDP socket while keeping the configured target intact."),
+			new("Reconnect OutSim", "Dispose and recreate the OutSim UDP socket for the current endpoint."),
+		];
+
+		private void RefreshTelemetryOverlay()
+		{
+			if (_telemetryOverlay == null)
+			{
+				return;
+			}
+
+			_telemetryOverlay.Items = BuildTelemetryMenuItems();
+			_telemetryOverlay.SelectedIndex = _telemetryMenuSelectedIndex;
+			_telemetryOverlay.VehicleName = GetCurrentVehicleName();
+			_telemetryOverlay.StatusText = _status;
+			_telemetryOverlay.OutGaugeSummary = BuildOutGaugeSummary();
+			_telemetryOverlay.OutSimSummary = BuildOutSimSummary();
+		}
+
+		private string BuildOutGaugeSummary()
+		{
+			var endpoint = DescribeTelemetryEndpoint(OutGaugeIp, OutGaugePort);
+			var enabledState = OutGaugeEnabled ? "enabled" : "disabled";
+			var connectionState = DescribeSocketState(_outGaugeConnectionRequested, _outGaugeClient != null, _outGaugeSendFailed);
+			return $"OutGauge // {enabledState} // {endpoint} // {connectionState} // {(OutGaugeId == 0 ? "id=none" : $"id={OutGaugeId}")}";
+		}
+
+		private string BuildOutSimSummary()
+		{
+			var endpoint = DescribeTelemetryEndpoint(OutSimIp, OutSimPort);
+			var enabledState = OutSimEnabled ? "enabled" : "disabled";
+			var connectionState = DescribeSocketState(_outSimConnectionRequested, _outSimClient != null, _outSimSendFailed);
+			return $"OutSim // {enabledState} // {endpoint} // {connectionState} // {(OutSimId == 0 ? "id=none" : $"id={OutSimId}")}";
+		}
+
+		private static string DescribeTelemetryEndpoint(string? host, int port)
+		{
+			var trimmedHost = host?.Trim();
+			return string.IsNullOrWhiteSpace(trimmedHost) || port is < 1 or > 65535
+				? "endpoint not configured"
+				: $"{trimmedHost}:{port}";
+		}
+
+		private static string DescribeSocketState(bool connectionRequested, bool socketOpen, bool sendFailed)
+		{
+			if (!connectionRequested)
+			{
+				return "socket disconnected";
+			}
+
+			if (!socketOpen)
+			{
+				return "socket closed";
+			}
+
+			return sendFailed ? "socket open, last send failed" : "socket open";
+		}
+
+		private void SetOutGaugeEnabled(bool enabled)
+		{
+			OutGaugeEnabled = enabled;
+			_outGaugeElapsed = 0f;
+			if (!enabled)
+			{
+				DisposeOutGaugeClient();
+				return;
+			}
+
+			if (_outGaugeConnectionRequested)
+			{
+				EnsureOutGaugeClient();
+			}
+		}
+
+		private void SetOutSimEnabled(bool enabled)
+		{
+			OutSimEnabled = enabled;
+			_outSimElapsed = 0f;
+			_outSimHasPreviousLinearVelocity = false;
+			if (!enabled)
+			{
+				DisposeOutSimClient();
+				return;
+			}
+
+			if (_outSimConnectionRequested)
+			{
+				EnsureOutSimClient();
+			}
+		}
+
+		private void ConnectOutGauge()
+		{
+			_outGaugeConnectionRequested = true;
+			EnsureOutGaugeClient();
+			SetTelemetryStatus($"OutGauge socket connect requested ({DescribeSocketState(_outGaugeConnectionRequested, _outGaugeClient != null, _outGaugeSendFailed)}).");
+		}
+
+		private void DisconnectOutGauge()
+		{
+			_outGaugeConnectionRequested = false;
+			DisposeOutGaugeClient();
+			SetTelemetryStatus("OutGauge socket disconnected.");
+		}
+
+		private void ReconnectOutGauge()
+		{
+			_outGaugeConnectionRequested = true;
+			DisposeOutGaugeClient();
+			EnsureOutGaugeClient();
+			SetTelemetryStatus($"OutGauge socket reconnected ({DescribeSocketState(_outGaugeConnectionRequested, _outGaugeClient != null, _outGaugeSendFailed)}).");
+		}
+
+		private void ConnectOutSim()
+		{
+			_outSimConnectionRequested = true;
+			EnsureOutSimClient();
+			SetTelemetryStatus($"OutSim socket connect requested ({DescribeSocketState(_outSimConnectionRequested, _outSimClient != null, _outSimSendFailed)}).");
+		}
+
+		private void DisconnectOutSim()
+		{
+			_outSimConnectionRequested = false;
+			DisposeOutSimClient();
+			SetTelemetryStatus("OutSim socket disconnected.");
+		}
+
+		private void ReconnectOutSim()
+		{
+			_outSimConnectionRequested = true;
+			DisposeOutSimClient();
+			EnsureOutSimClient();
+			SetTelemetryStatus($"OutSim socket reconnected ({DescribeSocketState(_outSimConnectionRequested, _outSimClient != null, _outSimSendFailed)}).");
+		}
+
+		private void SetTelemetryStatus(string message)
+		{
+			_status = $"Telemetry: {message}";
+			RefreshTelemetryOverlay();
 		}
 	}
 }


### PR DESCRIPTION
## Summary by Sourcery

Add an in-game telemetry control menu and overlay for managing OutGauge and OutSim UDP telemetry connections from the pause menu.

New Features:
- Introduce a Telemetry pause-menu entry and dedicated menu screen for configuring telemetry while in-game.
- Add a TelemetryOverlay HUD panel that lists telemetry actions, shows current vehicle and connection summaries, and reports telemetry status messages.

Enhancements:
- Default OutGauge telemetry to enabled and track explicit connection requests for OutGauge and OutSim to better control socket lifecycle and status reporting.
- Provide detailed OutGauge and OutSim endpoint and socket-state summaries to surface configuration and failure information in the UI.

Tests:
- Extend pause menu tests to cover the new Telemetry entry and its pause-menu slot mapping.
- Add input tests to verify telemetry menu action resolution for the various Telemetry menu options.